### PR TITLE
Update SPI and I2C as 'Completed' in roadmaps tr/en

### DIFF
--- a/en/roadmap.mdx
+++ b/en/roadmap.mdx
@@ -68,8 +68,8 @@ status and pending tasks are in the table below.
 | Loading NuttX onto the R5 core via the remoteproc mechanism by U-Boot or Linux                              | `Completed`                    |
 | Communication between NuttX running on the R5 core and Linux running on the A53 core via Texas IPC mechanism | Volunteer Developer Needed     |
 | PWM driver support                                                                                          | Volunteer Developer Needed     |
-| SPI driver support                                                                                          | Volunteer Developer Needed     |
-| I2C driver support                                                                                          | Volunteer Developer Needed     |
+| SPI driver support                                                                                          | `Completed`     |
+| I2C driver support                                                                                          | `Completed`     |
 | Pinmux settings for all pins on the 40-pin HAT                                                              | Volunteer Developer Needed     |
 | Running Ardupilot and PX4 autopilots as apps on the Nuttx OS on Gemstone                                    | Volunteer Developer Needed     |
 | CAN Bus driver support                                                                                      | Volunteer Developer Needed     |

--- a/tr/roadmap.mdx
+++ b/tr/roadmap.mdx
@@ -68,8 +68,8 @@ hedeflenmektedir. Aşağıdaki tabloda güncel durum ve yapılacaklar bulunmakta
 | Seri port sürücü desteği                                                                                    | `Tamamlandı`                   |
 | NuttShell (nsh) konsoluna erişilmesi                                                                        | `Tamamlandı`                   |
 | NuttX'in remoteproc mekanizması ile U-Boot ya da Linux tarafından R5 çekirdeğine yüklenmesi                 | `Tamamlandı`                   |
-| I2C sürücü desteği                                                                                          | Gönüllü Geliştirici Bekleniyor |
-| SPI sürücü desteği                                                                                          | Gönüllü Geliştirici Bekleniyor |
+| I2C sürücü desteği                                                                                          | `Tamamlandı` |
+| SPI sürücü desteği                                                                                          | `Tamamlandı` |
 | PWM sürücü desteği                                                                                          | Gönüllü Geliştirici Bekleniyor |
 | 40-pin HAT'te yer alan tüm pinler için pinmux ayarlamaları                                                  | Gönüllü Geliştirici Bekleniyor |
 | Gemstone üzerindeki Nuttx işletim sisteminde PX4 otopilotunun app olarak çalıştırılması                     | Gönüllü Geliştirici Bekleniyor |


### PR DESCRIPTION
Updates roadmap.mdx (TR/EN): SPI and I2C driver tasks are now marked
  as completed. Both drivers are implemented and verified on t3-gem-o1
  hardware