### PR TITLE
docs: update PWM as 'Completed' in roadmaps en/tr

### DIFF
--- a/en/roadmap.mdx
+++ b/en/roadmap.mdx
@@ -72,7 +72,7 @@ status and pending tasks are in the table below.
 | Loading NuttX onto the R5 core via the remoteproc mechanism by U-Boot or Linux                               | `Completed`                    |
 | I2C driver support                                                                                           | `Completed`                    |
 | SPI driver support                                                                                           | `Completed`                    |
-| PWM driver support                                                                                           | **Continues**                  |
+| PWM driver support                                                                                           | `Completed`                    |
 | Pinmux settings for all pins on the 40-pin HAT                                                               | Volunteer Developer Needed     |
 | Running Ardupilot and PX4 autopilots as apps on the Nuttx OS on Gemstone                                     | Volunteer Developer Needed     |
 | Communication between NuttX running on the R5 core and Linux running on the A53 core via Texas IPC mechanism | Volunteer Developer Needed     |

--- a/tr/roadmap.mdx
+++ b/tr/roadmap.mdx
@@ -72,9 +72,9 @@ hedeflenmektedir. Aşağıdaki tabloda güncel durum ve yapılacaklar bulunmakta
 | Seri port sürücü desteği                                                                                    | `Tamamlandı`                   |
 | NuttShell (nsh) konsoluna erişilmesi                                                                        | `Tamamlandı`                   |
 | NuttX'in remoteproc mekanizması ile U-Boot ya da Linux tarafından R5 çekirdeğine yüklenmesi                 | `Tamamlandı`                   |
-| I2C sürücü desteği                                                                                          | `Tamamlandı` |
-| SPI sürücü desteği                                                                                          | `Tamamlandı` |
-| PWM sürücü desteği                                                                                          | **Devam Ediyor** |
+| I2C sürücü desteği                                                                                          | `Tamamlandı`                   |
+| SPI sürücü desteği                                                                                          | `Tamamlandı`                   |
+| PWM sürücü desteği                                                                                          | `Tamamlandı`                   |
 | 40-pin HAT'te yer alan tüm pinler için pinmux ayarlamaları                                                  | Gönüllü Geliştirici Bekleniyor |
 | Gemstone üzerindeki Nuttx işletim sisteminde PX4 otopilotunun app olarak çalıştırılması                     | Gönüllü Geliştirici Bekleniyor |
 | R5 çekirdeğinde çalışan NuttX ile A53 çekirdeğinde çalışan Linux arası Texas IPC mekanizması ile haberleşme | Gönüllü Geliştirici Bekleniyor |


### PR DESCRIPTION
Updates roadmap.mdx (TR/EN): PWM driver task is now marked as completed. The driver is implemented and verified on t3-gem-o1 hardware