### PR TITLE
docs: update ECAP(APWM) and pinmux in roadmap (en/tr), add missing roadmap contents, update Nuttx page (en/tr)

### DIFF
--- a/en/projects/nuttx.mdx
+++ b/en/projects/nuttx.mdx
@@ -4,8 +4,8 @@ description: 'NuttX Operating System'
 ---
 
 <Warning>
-NuttX support for Gemstone is still in the development phase. It is not possible to use all peripherals on the board
-such as I2C, SPI, PWM, CAN Bus.
+NuttX support for Gemstone is still in the development phase. It is not possible to use some peripherals on the board
+such as CAN Bus.
 </Warning>
 
 NuttX is an open-source operating system designed for real-time applications. Compliant with POSIX and ANSI standards,

--- a/en/roadmap.mdx
+++ b/en/roadmap.mdx
@@ -73,7 +73,8 @@ status and pending tasks are in the table below.
 | I2C driver support                                                                                           | `Completed`                    |
 | SPI driver support                                                                                           | `Completed`                    |
 | PWM driver support                                                                                           | `Completed`                    |
-| Pinmux settings for all pins on the 40-pin HAT                                                               | Volunteer Developer Needed     |
+| ECAP(APWM) driver support                                                                                    | `Completed`                    |
+| Pinmux settings for all pins on the 40-pin HAT                                                               | `Completed`                    |
 | Running Ardupilot and PX4 autopilots as apps on the Nuttx OS on Gemstone                                     | Volunteer Developer Needed     |
 | Communication between NuttX running on the R5 core and Linux running on the A53 core via Texas IPC mechanism | Volunteer Developer Needed     |
 | CAN Bus driver support                                                                                       | Volunteer Developer Needed     |

--- a/tr/projects/nuttx.mdx
+++ b/tr/projects/nuttx.mdx
@@ -4,7 +4,7 @@ description: 'NuttX İşletim Sistemi'
 ---
 
 <Warning>
-Gemstone için NuttX desteği henüz geliştirme aşamasındadır. Kartın üzerindeki I2C, SPI, PWM, CAN Bus gibi tüm çevre 
+Gemstone için NuttX desteği henüz geliştirme aşamasındadır. Kartın üzerindeki CAN Bus gibi bazı çevre 
 birimleri kullanmak mümkün değildir.
 </Warning>
 

--- a/tr/roadmap.mdx
+++ b/tr/roadmap.mdx
@@ -75,10 +75,13 @@ hedeflenmektedir. Aşağıdaki tabloda güncel durum ve yapılacaklar bulunmakta
 | I2C sürücü desteği                                                                                          | `Tamamlandı`                   |
 | SPI sürücü desteği                                                                                          | `Tamamlandı`                   |
 | PWM sürücü desteği                                                                                          | `Tamamlandı`                   |
-| 40-pin HAT'te yer alan tüm pinler için pinmux ayarlamaları                                                  | Gönüllü Geliştirici Bekleniyor |
+| ECAP(APWM) sürücü desteği                                                                                   | `Tamamlandı`                   |
+| 40-pin HAT'te yer alan tüm pinler için pinmux ayarlamaları                                                  | `Tamamlandı`                   |
 | Gemstone üzerindeki Nuttx işletim sisteminde PX4 otopilotunun app olarak çalıştırılması                     | Gönüllü Geliştirici Bekleniyor |
 | R5 çekirdeğinde çalışan NuttX ile A53 çekirdeğinde çalışan Linux arası Texas IPC mekanizması ile haberleşme | Gönüllü Geliştirici Bekleniyor |
 | CAN Bus sürücü desteği                                                                                      | Gönüllü Geliştirici Bekleniyor |
+| USB sürücü desteği                                                                                          | Gönüllü Geliştirici Bekleniyor |
+| SD card ve eMMC sürücü desteği                                                                              | Gönüllü Geliştirici Bekleniyor |
 
 ## ChibiOS + Ardupilot
 


### PR DESCRIPTION
Update ECAP + pinmux in roadmap (en/tr), add missing USB, SD card and eMMC driver support columns to roadmap (tr)
Update Nuttx page to remove completed peripherals from warning