### PR TITLE
docs: update ChibiOS and ArduPilot roadmap progress

### DIFF
--- a/en/roadmap.mdx
+++ b/en/roadmap.mdx
@@ -29,8 +29,8 @@ To contribute by taking part in the relevant projects, visit their Github pages 
   `Not Started Yet`
 </Card>
 
-<Card horizontal arrow="true" title="ChibiOS + Ardupilot" icon="clock" href="./roadmap#chibios-+-ardupilot">
-  `Not Started Yet`
+<Card horizontal arrow="true" title="ChibiOS + Ardupilot" icon="spinner" href="./roadmap#chibios-+-ardupilot">
+  <Progress percent={60} />
 </Card>
 
 <Card horizontal arrow="true" title="Linux Kernel Version 7" icon="clock" href="./roadmap#linux-kernel-version-7">
@@ -107,22 +107,21 @@ cores.
   </Frame>
 </Columns>
 
-The planned tasks are listed in the table below.
+The current status and pending tasks are in the table below.
 
-|                                                                                                              |                                |
-|:-------------------------------------------------------------------------------------------------------------|-------------------------------:|
-| Running NuttX on R5 cores                                                                                    | `Completed`                    |
-| GPIO driver support                                                                                          | `Completed`                    |
-| Serial port driver support                                                                                   | `Completed`                    |
-| Access to NuttShell (nsh) console                                                                            | `Completed`                    |
-| Loading NuttX onto the R5 core via U-Boot or Linux using NuttX's remoteproc mechanism                        | `Completed`                    |
-| I2C driver support                                                                                           | Awaiting Volunteer Developer   |
-| SPI driver support                                                                                           | Awaiting Volunteer Developer   |
-| PWM driver support                                                                                           | Awaiting Volunteer Developer   |
-| Pinmux configurations for all pins on the 40-pin HAT                                                         | Awaiting Volunteer Developer   |
-| Running PX4 autopilot as an application on the NuttX operating system on Gemstone                            | Awaiting Volunteer Developer   |
-| Communication between NuttX running on the R5 core and Linux running on the A53 core via Texas IPC mechanism | Awaiting Volunteer Developer   |
-| CAN Bus driver support                                                                                       | Awaiting Volunteer Developer   |
+|                                                                                                             |                                |
+|:------------------------------------------------------------------------------------------------------------|-------------------------------:|
+| Porting the ChibiOS HAL to the AM67A Cortex-R5 cores                                                        | **In Progress**                |
+| Loading ChibiOS onto an R5 core from U-Boot or Linux using remoteproc                                       | `Completed`                    |
+| Serial port (UART) driver support and console access                                                        | `Completed`                    |
+| GPIO driver support                                                                                         | `Completed`                    |
+| Building ArduPilot for the R5 cores using the AP_HAL_ChibiOS layer                                          | `Completed`                    |
+| Running ArduPilot as a functional autopilot on ChibiOS                                                      | **In Progress**                |
+| SPI and I2C driver support for sensors such as IMUs and barometers                                          | `Completed`                    |
+| PWM driver support for motor and servo outputs                                                              | `Completed`                    |
+| CAN Bus (DroneCAN) driver support                                                                           | Volunteer Developer Needed     |
+| Communication via Texas IPC between ChibiOS on the R5 core and Linux on the A53 cores                       | Volunteer Developer Needed     |
+| Establishing MAVLink telemetry and ground control station (GCS) connectivity                                | Volunteer Developer Needed     |
 
 ## PX4 Autopilot
 

--- a/tr/quickstart.mdx
+++ b/tr/quickstart.mdx
@@ -246,7 +246,7 @@ ekran görüntüsündeki gibi ilgili aygıtı listeleyecektir.
 #### 1.2.6. Sistem Özelleştir
 
 Yukarıdaki seçimler tamamlandıktan sonra Next butonuna tıkladığınızda otomatik olarak **Sistem Özelleştirme** ekranı
-açılacaktır. Bu ekran kurulumu yapılacak kartın giriş şifresi ve bir takım servislerin otomatik başlatılabilmesi
+açılacaktır. Bu ekran kurulumu yapılacak kartın giriş şifresi ve birtakım servislerin otomatik başlatılabilmesi
 için kullanılmaktadır.
 
 <AccordionGroup>

--- a/tr/roadmap.mdx
+++ b/tr/roadmap.mdx
@@ -30,8 +30,8 @@ ziyaret edininiz.
   `Henüz Başlamadı`
 </Card>
 
-<Card horizontal arrow="true" title="ChibiOS + Ardupilot" icon="clock" href="./roadmap#chibios-+-ardupilot">
-  `Henüz Başlamadı`
+<Card horizontal arrow="true" title="ChibiOS + Ardupilot" icon="spinner" href="./roadmap#chibios-+-ardupilot">
+  <Progress percent={60} />
 </Card>
 
 <Card horizontal arrow="true" title="Linux Kernel Version 7" icon="clock" href="./roadmap#linux-kernel-version-7">
@@ -109,18 +109,18 @@ döngüsü Cortex-R5 çekirdeklerinde kesintisiz olarak yürütülebilecektir.
   </Frame>
 </Columns>
 
-Aşağıdaki tabloda yapılması planlanan çalışmalar bulunmaktadır.
+Aşağıdaki tabloda güncel durum ve yapılacak çalışmalar bulunmaktadır.
 
 |                                                                                                             |                                |
 |:------------------------------------------------------------------------------------------------------------|-------------------------------:|
-| ChibiOS HAL'ının AM67a Cortex-R5 çekirdekleri için port edilmesi                                            | Gönüllü Geliştirici Bekleniyor |
-| ChibiOS'un remoteproc mekanizması ile U-Boot ya da Linux tarafından R5 çekirdeğine yüklenmesi               | Gönüllü Geliştirici Bekleniyor |
-| Seri port (UART) sürücü desteği ve konsol erişimi                                                           | Gönüllü Geliştirici Bekleniyor |
-| GPIO sürücü desteği                                                                                         | Gönüllü Geliştirici Bekleniyor |
-| Ardupilot'un AP_HAL_ChibiOS katmanı kullanılarak R5 çekirdekleri için derlenmesi                            | Gönüllü Geliştirici Bekleniyor |
-| Ardupilot'un ChibiOS üzerinde otopilot olarak çalıştırılması                                                | Gönüllü Geliştirici Bekleniyor |
-| SPI ve I2C sürücü desteği (IMU, barometre vb. sensörler için)                                               | Gönüllü Geliştirici Bekleniyor |
-| PWM sürücü desteği (motor ve servo çıkışları için)                                                          | Gönüllü Geliştirici Bekleniyor |
+| ChibiOS HAL'ının AM67a Cortex-R5 çekirdekleri için port edilmesi                                            | **Devam Ediyor**               |
+| ChibiOS'un remoteproc mekanizması ile U-Boot ya da Linux tarafından R5 çekirdeğine yüklenmesi               | `Tamamlandı`                   |
+| Seri port (UART) sürücü desteği ve konsol erişimi                                                           | `Tamamlandı`                   |
+| GPIO sürücü desteği                                                                                         | `Tamamlandı`                   |
+| Ardupilot'un AP_HAL_ChibiOS katmanı kullanılarak R5 çekirdekleri için derlenmesi                            | `Tamamlandı`                   |
+| Ardupilot'un ChibiOS üzerinde otopilot olarak çalıştırılması                                                | **Devam Ediyor**               |
+| SPI ve I2C sürücü desteği (IMU, barometre vb. sensörler için)                                               | `Tamamlandı`                   |
+| PWM sürücü desteği (motor ve servo çıkışları için)                                                          | `Tamamlandı`                   |
 | CAN Bus (DroneCAN) sürücü desteği                                                                           | Gönüllü Geliştirici Bekleniyor |
 | R5 çekirdeğinde çalışan ChibiOS ile A53 çekirdeğinde çalışan Linux arası Texas IPC ile haberleşme           | Gönüllü Geliştirici Bekleniyor |
 | MAVLink telemetri ve yer kontrol istasyonu (GCS) bağlantısının sağlanması                                   | Gönüllü Geliştirici Bekleniyor |


### PR DESCRIPTION
## Summary

* Update the ChibiOS and ArduPilot roadmap progress to 60% in both Turkish and English.
* Mark completed and ongoing tasks according to the current implementation status.
* Restore the correct ChibiOS task list in the English roadmap.
* Fix a Turkish spelling issue in the quickstart guide (`bir takım` → `birtakım`).

## Validation

* Confirmed that the Turkish and English roadmap entries are consistent.
* Confirmed that the MDX changes contain no whitespace errors.
