### PR TITLE
Kablosuz modül bilgileri düzeltmesi

### DIFF
--- a/tr/boards/o1/introduction.mdx
+++ b/tr/boards/o1/introduction.mdx
@@ -94,9 +94,9 @@ Texas Instruments AM67A işlemcisi tabanlı yüksek performanslı geliştirme ka
 
 <CardGroup cols={2}>
   <Card title="Kablosuz" icon="wifi">
-    <SnippetCardEntry header="TI WL1835MOD" link="https://www.ti.com/product/WL1835MOD">
-      Wi-Fi 4 (802.11n), harici iki adet 2.4 GHz anten<br></br>
-      Bluetooth 5.1, Bluetooth Low Energy (BLE)
+    <SnippetCardEntry header="Fn-Link 6222B-SRC" link="https://www.fn-link.com/6222B-SRC-Wi-Fi-Module-pd40585380.html">
+      Wi-Fi 5 (802.11a/b/g/n/ac), SDIO 3.0 arayüzü<br></br>
+      Bluetooth 5.0, UART arayüzü
     </SnippetCardEntry>
   </Card>
 


### PR DESCRIPTION
Yanlış listelenen TI WL1835MOD, kartta kullanılan Realtek tabanlı Fn-Link 6222B-SRC modülüyle değiştirildi. Ürün bağlantısı ile Wi-Fi ve Bluetooth bilgileri güncellendi.

Doğrulama: `npx mint validate` ve `git diff --check`.
