### PR TITLE
docs: correct O1 wireless module information

### DIFF
--- a/en/boards/o1/introduction.mdx
+++ b/en/boards/o1/introduction.mdx
@@ -94,9 +94,9 @@ High-performance development board based on Texas Instruments AM67A processor
 
 <CardGroup cols={2}>
   <Card title="Wireless" icon="wifi">
-    <SnippetCardEntry header="TI WL1835MOD" link="https://www.ti.com/product/WL1835MOD">
-      Wi-Fi 4 (802.11n), external dual 2.4 GHz antennas<br></br>
-      Bluetooth 5.1, Bluetooth Low Energy (BLE)
+    <SnippetCardEntry header="Fn-Link 6222B-SRC" link="https://www.fn-link.com/6222B-SRC-Wi-Fi-Module-pd40585380.html">
+      Wi-Fi 5 (802.11a/b/g/n/ac), SDIO 3.0 interface<br></br>
+      Bluetooth 5.0, UART interface
     </SnippetCardEntry>
   </Card>
 

--- a/tr/boards/o1/introduction.mdx
+++ b/tr/boards/o1/introduction.mdx
@@ -94,9 +94,9 @@ Texas Instruments AM67A işlemcisi tabanlı yüksek performanslı geliştirme ka
 
 <CardGroup cols={2}>
   <Card title="Kablosuz" icon="wifi">
-    <SnippetCardEntry header="TI WL1835MOD" link="https://www.ti.com/product/WL1835MOD">
-      Wi-Fi 4 (802.11n), harici iki adet 2.4 GHz anten<br></br>
-      Bluetooth 5.1, Bluetooth Low Energy (BLE)
+    <SnippetCardEntry header="Fn-Link 6222B-SRC" link="https://www.fn-link.com/6222B-SRC-Wi-Fi-Module-pd40585380.html">
+      Wi-Fi 5 (802.11a/b/g/n/ac), SDIO 3.0 arayüzü<br></br>
+      Bluetooth 5.0, UART arayüzü
     </SnippetCardEntry>
   </Card>
 


### PR DESCRIPTION
Corrects the incorrectly listed TI WL1835MOD in the Turkish and English O1 board pages by replacing it with the Realtek-based Fn-Link 6222B-SRC module. The product link and Wi-Fi/Bluetooth details are updated accordingly.

Validated with `npx mint validate` and `git diff --check`.
