### PR TITLE
docs: PX4 autostart, networking and QGroundControl guide

### DIFF
--- a/en/projects/px4.mdx
+++ b/en/projects/px4.mdx
@@ -6,14 +6,17 @@ description: 'PX4 Autopilot'
 <Warning>
 PX4 support for Gemstone is still in the development phase. It runs on the
 main-domain R5F core, and some peripherals on the board, such as CAN Bus, are
-not yet available.
+not yet available. The board also has no barometer or GPS, so altitude and
+absolute position estimation are limited.
 </Warning>
 
 PX4 is an open-source autopilot platform for drones and other unmanned vehicles.
 It provides a complete flight-control stack, from low-level sensor drivers up to
 vehicle control and mission execution. On the Gemstone board, PX4 runs on the
 R5F cores on top of NuttX, using the same custom `t3-gem-o1` configuration
-created for the bare NuttX build.
+created for the bare NuttX build. The flight software starts automatically
+when the board boots, and the QGroundControl ground control application
+connects to the vehicle over the network.
 
 Unlike a standalone NuttX build, PX4 vendors both NuttX and its application
 framework as git submodules. A recursive clone therefore pulls the correct,
@@ -22,35 +25,15 @@ NuttX separately.
 
 ## 1. Compilation
 
-### 1.1. Installing Dependencies and Toolchain
+### 1.1. Downloading Source Codes
 
-PX4 is compiled with the `gcc-arm-none-eabi` cross‑compiler for the ARM
-Cortex‑R5F cores, and its build system additionally relies on a set of Python
-tools such as `kconfiglib`, `empy` and `jinja2`.
-
-On Ubuntu/Debian systems, install the toolchain and the general prerequisites
-with the package manager:
+On Ubuntu/Debian systems, first install the tools needed for downloading and
+compiling with the package manager:
 
 ```bash
 sudo apt update
-sudo apt install git make cmake ninja-build gcc-arm-none-eabi python3-venv
+sudo apt install git make cmake ninja-build gcc-arm-none-eabi python3-venv picocom
 ```
-
-Because recent Debian/Ubuntu releases restrict system‑wide `pip` installations,
-install the Python tools into a virtual environment:
-
-```bash
-python3 -m venv ~/px4-venv
-source ~/px4-venv/bin/activate
-pip install -r Tools/setup/requirements.txt
-```
-
-The `requirements.txt` file lives inside the PX4 source tree, so run the
-`pip install` step after downloading the sources (section 1.2). Activate the
-environment with `source ~/px4-venv/bin/activate` in every new shell before
-building.
-
-### 1.2. Downloading Source Codes
 
 PX4 references the Gemstone NuttX and NuttX‑apps as git submodules, so the
 sources are downloaded with a single recursive clone:
@@ -63,15 +46,29 @@ git clone --recursive https://github.com/t3gemstone/PX4-Autopilot.git
 cd PX4-Autopilot
 ```
 
-The `--recursive` flag checks out the correct NuttX (the Gemstone `px4` branch)
-and NuttX‑apps into the `platforms/nuttx/NuttX` directory, so a separate NuttX
-download is not required. If you cloned without `--recursive`, fetch the
+If you cloned without `--recursive`, fetch the
 submodules afterwards with `git submodule update --init --recursive`.
+
+### 1.2. Setting Up the Python Environment
+
+PX4's build system relies on a set of Python tools such as `kconfiglib`,
+`empy` and `jinja2`. Because recent Debian/Ubuntu releases restrict
+system‑wide `pip` installations, install them into a virtual environment
+(run from the `PX4-Autopilot` directory cloned in section 1.1):
+
+```bash
+python3 -m venv ~/px4-venv
+source ~/px4-venv/bin/activate
+pip install -r Tools/setup/requirements.txt
+```
+
+Activate the environment with `source ~/px4-venv/bin/activate` in every new
+shell before building.
 
 ### 1.3. Compiling the Project
 
 PX4 builds a specific board target directly, so no separate configuration step
-is required. With the Python environment from section 1.1 active, compile the
+is required. With the Python environment from section 1.2 active, compile the
 Gemstone board image:
 
 ```bash
@@ -98,12 +95,31 @@ Program files to be loaded onto the cores via remoteproc must be copied to the
 remoteproc mechanism will automatically load the programs onto the relevant
 cores. Follow the steps below to run PX4 using remoteproc.
 
-1.  Copy the `build/t3gemstone_o1_default/t3gemstone_o1_default.elf` file
-    resulting from the compilation to the `/lib/firmware` directory with the
-    name `j722s-main-r5f0_0-fw`.
-2.  Reboot the board.
-3.  You can access NuttShell by connecting a USB-to-TTL device to the
-    UART-MAIN1's GPIO-14 (TX) and GPIO-15 (RX) pins on the 40-pin HAT.
+1.  Copy the compiled image to the board (the board is reachable at
+    `192.168.7.2` when connected over the USB Type-C cable):
+
+    ```bash
+    ubuntu@host:~$ scp build/t3gemstone_o1_default/t3gemstone_o1_default.elf gemstone@192.168.7.2:~
+    ```
+
+2.  On the board, place the image in the `/lib/firmware` directory with the
+    predefined name and reboot:
+
+    ```bash
+    gemstone@t3-gem-o1:~$ sudo cp ~/t3gemstone_o1_default.elf /lib/firmware/j722s-main-r5f0_0-fw
+    gemstone@t3-gem-o1:~$ sudo reboot
+    ```
+
+3.  Connect a USB-to-TTL device to the UART-MAIN1's GPIO-14 (TX) and
+    GPIO-15 (RX) pins on the 40-pin HAT, then open the NuttShell console
+    from your PC (exit with `Ctrl-A` followed by `Ctrl-X`; the device name
+    may differ, e.g. `/dev/ttyUSB1`, if other USB serial adapters are
+    connected):
+
+    ```bash
+    ubuntu@host:~$ picocom -b 115200 /dev/ttyUSB0
+    ```
+
 4.  From the opened `nsh` console you can inspect the running system with
     commands such as `ver all`, `top`, and `uorb status`.
 
@@ -111,7 +127,9 @@ cores. Follow the steps below to run PX4 using remoteproc.
 
 The on‑board InvenSense ICM‑20948, a 9‑axis IMU with an accelerometer,
 gyroscope and an integrated AK09916 magnetometer, is connected to the R5F over
-SPI. Start its driver from the `nsh` console:
+SPI. The boot script (section 4) already starts the driver together with the
+rest of the flight stack; the commands below are useful when experimenting
+with the driver on its own:
 
 ```bash
 nsh> icm20948 -s -b 1 -c 3 -M start
@@ -131,3 +149,146 @@ nsh> listener sensor_mag
 To observe the overall system, `uorb top` lists the publication rates of all
 active topics and `work_queue status` shows the timing of the driver's work
 queue.
+
+## 4. Flight Stack Autostart
+
+When the R5F starts, PX4 starts all of its components automatically: the sensor driver, attitude estimation, the
+flight controllers and the telemetry link. The board is configured as a Generic Quadcopter X airframe. No manual
+startup commands are needed.
+
+You can verify that the system is running from the `nsh` console. The `uorb top` command lists the data topics that
+PX4's components publish, together with their update rates; sensor and attitude topics updating at a steady rate mean
+the flight software is alive:
+
+```bash
+nsh> uorb top
+#  TOPIC NAME                    INST #SUB RATE #LOST #Q SIZE
+#  sensor_accel                     0    4  400     0  1  48
+#  vehicle_attitude                 0    6  100     0  1  56
+#  ...
+```
+
+The `listener` command prints the live content of a topic. For example, the vehicle's current orientation:
+
+```bash
+nsh> listener vehicle_attitude
+#  TOPIC: vehicle_attitude
+#   vehicle_attitude
+#    timestamp: 87243147 (0.021 seconds ago)
+#    q: [0.9998, 0.0011, -0.0134, 0.0092]
+```
+
+## 5. Networking and QGroundControl
+
+PX4 and the Linux side are connected by a network link: `eth0` on NuttX and `eth1` on Linux.
+
+- **NuttX IP**: `192.168.10.2`
+- **Linux `eth1` IP**: `192.168.10.1`
+- **MAVLink Port**: UDP `14550`
+
+### 5.1. Installing the Network Module
+
+Install the network module package and reboot the board:
+
+```bash
+gemstone@t3-gem-o1:~$ sudo apt update
+gemstone@t3-gem-o1:~$ sudo apt install kernel-module-virtio-net-6.12.24-ti
+gemstone@t3-gem-o1:~$ sudo reboot
+```
+
+### 5.2. Configuring the Link
+
+Configure the Linux side of the link (required after every boot):
+
+```bash
+gemstone@t3-gem-o1:~$ sudo nmcli device set eth1 managed no
+gemstone@t3-gem-o1:~$ sudo ip link set eth1 up
+gemstone@t3-gem-o1:~$ sudo ip addr add 192.168.10.1/24 dev eth1
+gemstone@t3-gem-o1:~$ sudo sysctl -w net.ipv4.ip_forward=1
+```
+
+Configure the NuttX side from the `nsh` console and verify the link:
+
+```bash
+nsh> ifconfig eth0 192.168.10.2 gw 192.168.10.1
+nsh> ifup eth0
+nsh> ping -c 3 192.168.10.1
+#  56 bytes from 192.168.10.1: icmp_seq=0 time=0.0 ms
+#  56 bytes from 192.168.10.1: icmp_seq=1 time=0.0 ms
+#  56 bytes from 192.168.10.1: icmp_seq=2 time=0.0 ms
+#  3 packets transmitted, 3 received, 0% packet loss
+```
+
+### 5.3. Reaching the Board Network from the PC
+
+Connect the Gemstone board to your PC via USB Type-C cable and add a route so that the `192.168.10.0/24` network is
+reachable through the board:
+
+```bash
+ubuntu@host:~$ sudo ip route add 192.168.10.0/24 via 192.168.7.2
+ubuntu@host:~$ ping -c 2 192.168.10.2
+#  64 bytes from 192.168.10.2: icmp_seq=1 ttl=64 time=0.42 ms
+#  64 bytes from 192.168.10.2: icmp_seq=2 ttl=64 time=0.31 ms
+```
+
+Find your PC's own address on the board network; it is used as the MAVLink target in the next step:
+
+```bash
+ubuntu@host:~$ ip route get 192.168.7.2 | grep -oP 'src \K\S+'
+#  192.168.7.60
+```
+
+### 5.4. QGroundControl Connection
+
+QGroundControl (QGC) is the application used to monitor and control the vehicle from a PC. Install it from
+[qgroundcontrol.com](https://qgroundcontrol.com/) and start it.
+
+Start the telemetry link from the `nsh` console, replacing `192.168.7.60` with your PC's address from the previous
+step:
+
+```bash
+nsh> mavlink start -u 14556 -o 14550 -t 192.168.7.60
+```
+
+QGC will automatically detect and connect to the vehicle if UDP autoconnect is enabled (default setting).
+
+## 6. Troubleshooting
+
+### 6.1. No eth1 Interface on Linux
+
+Check that the `virtio_net` module is loaded:
+
+```bash
+gemstone@t3-gem-o1:~$ lsmod | grep virtio_net
+#  virtio_net             45056  0
+#  net_failover           20480  1 virtio_net
+```
+
+If the command prints nothing, load the module manually and check again:
+
+```bash
+gemstone@t3-gem-o1:~$ sudo modprobe virtio_net
+```
+
+### 6.2. No MAVLink Connection
+
+Verify network configuration from the PC; the board must answer:
+
+```bash
+ubuntu@host:~$ ping -c 2 192.168.10.2
+#  64 bytes from 192.168.10.2: icmp_seq=1 ttl=64 time=0.42 ms
+```
+
+If there is no answer, repeat the steps in [Networking and QGroundControl](#5-networking-and-qgroundcontrol).
+
+Check that the telemetry link is running and transmitting on the NuttX side; the `tx rate` value must be greater
+than zero:
+
+```bash
+nsh> mavlink status
+#  instance #0:
+#          ...
+#          tx rate avg: 2543 B/s
+```
+
+Ensure QGC UDP autoconnect is enabled in Application Settings.

--- a/en/roadmap.mdx
+++ b/en/roadmap.mdx
@@ -75,8 +75,8 @@ status and pending tasks are in the table below.
 | PWM driver support                                                                                           | `Completed`                    |
 | ECAP(APWM) driver support                                                                                    | `Completed`                    |
 | Pinmux settings for all pins on the 40-pin HAT                                                               | `Completed`                    |
-| Running Ardupilot and PX4 autopilots as apps on the Nuttx OS on Gemstone                                     | Volunteer Developer Needed     |
-| Communication between NuttX running on the R5 core and Linux running on the A53 core via Texas IPC mechanism | Volunteer Developer Needed     |
+| Running the PX4 autopilot as an app on the Nuttx OS on Gemstone                                              | `Completed`                    |
+| Communication between NuttX running on the R5 core and Linux running on the A53 core via Texas IPC mechanism | `Completed`                    |
 | CAN Bus driver support                                                                                       | Volunteer Developer Needed     |
 | USB driver support                                                                                           | Volunteer Developer Needed     |
 | SD card and eMMC driver support                                                                              | Volunteer Developer Needed     |

--- a/tr/projects/px4.mdx
+++ b/tr/projects/px4.mdx
@@ -6,14 +6,17 @@ description: 'PX4 Otopilot'
 <Warning>
 Gemstone için PX4 desteği henüz geliştirme aşamasındadır. Ana domain R5F
 çekirdeğinde çalışır ve kartın üzerindeki CAN Bus gibi bazı çevre birimleri henüz
-kullanılamamaktadır.
+kullanılamamaktadır. Kartta barometre ve GPS de bulunmadığından irtifa ve mutlak
+konum kestirimi sınırlıdır.
 </Warning>
 
 PX4, dronlar ve diğer insansız araçlar için açık kaynaklı bir otopilot
 platformudur. Düşük seviyeli sensör sürücülerinden araç kontrolüne ve görev
 yürütmeye kadar uzanan eksiksiz bir uçuş kontrol yığını sunar. Gemstone kartında
 PX4, R5F çekirdeklerinde NuttX üzerinde, bare NuttX derlemesi için oluşturulan
-aynı özel `t3-gem-o1` konfigürasyonu kullanılarak çalışır.
+aynı özel `t3-gem-o1` konfigürasyonu kullanılarak çalışır. Uçuş yazılımı kart
+açıldığında otomatik olarak başlar ve QGroundControl yer kontrol uygulaması
+araca ağ üzerinden bağlanır.
 
 Bağımsız bir NuttX derlemesinin aksine PX4, hem NuttX'i hem de uygulama
 framework'ünü git submodule olarak barındırır. Bu nedenle recursive bir klonlama,
@@ -22,35 +25,15 @@ indirmenize veya derlemenize gerek yoktur.
 
 ## 1. Derleme
 
-### 1.1. Gereksinimleri ve Toolchain'i Kurma
+### 1.1. Kaynak Kodları İndirme
 
-PX4, ARM Cortex‑R5F çekirdekleri için `gcc-arm-none-eabi` çapraz derleyicisi ile
-derlenir ve build sistemi ayrıca `kconfiglib`, `empy` ve `jinja2` gibi bir dizi
-Python aracına dayanır.
-
-Ubuntu/Debian sistemlerde toolchain'i ve genel gereksinimleri paket yöneticisi
-ile kurabilirsiniz:
+Ubuntu/Debian sistemlerde önce indirme ve derleme için gereken araçları paket
+yöneticisi ile kurun:
 
 ```bash
 sudo apt update
-sudo apt install git make cmake ninja-build gcc-arm-none-eabi python3-venv
+sudo apt install git make cmake ninja-build gcc-arm-none-eabi python3-venv picocom
 ```
-
-Güncel Debian/Ubuntu sürümleri sistem genelinde `pip` kurulumunu
-kısıtladığından, Python araçlarını bir sanal ortama kurun:
-
-```bash
-python3 -m venv ~/px4-venv
-source ~/px4-venv/bin/activate
-pip install -r Tools/setup/requirements.txt
-```
-
-`requirements.txt` dosyası PX4 kaynak ağacının içinde yer aldığından, `pip
-install` adımını kaynak kodları indirdikten (bölüm 1.2) sonra çalıştırın. Derleme
-öncesinde her yeni terminalde ortamı `source ~/px4-venv/bin/activate` ile
-aktifleştirin.
-
-### 1.2. Kaynak Kodları İndirme
 
 PX4, Gemstone NuttX'ini ve NuttX‑apps'i git submodule olarak referans alır; bu
 nedenle kaynak kodlar tek bir recursive klonlama ile indirilir:
@@ -68,10 +51,26 @@ cd PX4-Autopilot
 gerekmez. `--recursive` olmadan klonladıysanız, submodule'leri sonradan
 `git submodule update --init --recursive` ile çekebilirsiniz.
 
+### 1.2. Python Ortamının Kurulumu
+
+PX4'ün build sistemi `kconfiglib`, `empy` ve `jinja2` gibi bir dizi Python
+aracına dayanır. Güncel Debian/Ubuntu sürümleri sistem genelinde `pip`
+kurulumunu kısıtladığından, bu araçları bir sanal ortama kurun (bölüm 1.1'de
+klonlanan `PX4-Autopilot` dizininden çalıştırın):
+
+```bash
+python3 -m venv ~/px4-venv
+source ~/px4-venv/bin/activate
+pip install -r Tools/setup/requirements.txt
+```
+
+Derleme öncesinde her yeni terminalde ortamı
+`source ~/px4-venv/bin/activate` ile aktifleştirin.
+
 ### 1.3. Projeyi Derleme
 
 PX4, belirli bir kart hedefini doğrudan derler; bu nedenle ayrı bir konfigürasyon
-adımı gerekmez. Bölüm 1.1'deki Python ortamı aktifken Gemstone kart imajını
+adımı gerekmez. Bölüm 1.2'deki Python ortamı aktifken Gemstone kart imajını
 derleyin:
 
 ```bash
@@ -110,7 +109,8 @@ remoteproc ile çalıştırmak için aşağıdaki adımları takip edin.
 
 Kart üzerindeki InvenSense ICM‑20948 bir ivmeölçer, jiroskop ve entegre
 AK09916 manyetometre içeren 9 eksenli bir IMU R5F'ye SPI üzerinden bağlıdır.
-Sürücüsünü `nsh` konsolundan başlatın:
+Açılış betiği (bölüm 4) sürücüyü uçuş yığınının geri kalanıyla birlikte zaten
+başlatır; aşağıdaki komutlar sürücüyle tek başına deney yaparken kullanışlıdır:
 
 ```bash
 nsh> icm20948 -s -b 1 -c 3 -M start
@@ -129,3 +129,146 @@ nsh> listener sensor_mag
 
 Genel sistemi gözlemlemek için `uorb top` tüm aktif topic'lerin yayın oranlarını,
 `work_queue status` ise sürücünün iş kuyruğunun zamanlamasını gösterir.
+
+## 4. Uçuş Yazılımının Otomatik Başlatılması
+
+R5F açıldığında PX4 tüm bileşenlerini otomatik olarak başlatır: sensör sürücüsü, duruş (attitude) kestirimi, uçuş
+kontrolcüleri ve telemetri bağlantısı. Kart, Generic Quadcopter X gövdesi olarak yapılandırılmıştır. Elle başlatma
+komutlarına gerek yoktur.
+
+Sistemin çalıştığını `nsh` konsolundan doğrulayabilirsiniz. `uorb top` komutu, PX4 bileşenlerinin yayınladığı veri
+topic'lerini güncelleme oranlarıyla birlikte listeler; sensör ve duruş topic'lerinin düzenli bir hızda güncelleniyor
+olması uçuş yazılımının çalıştığı anlamına gelir:
+
+```bash
+nsh> uorb top
+#  TOPIC NAME                    INST #SUB RATE #LOST #Q SIZE
+#  sensor_accel                     0    4  400     0  1  48
+#  vehicle_attitude                 0    6  100     0  1  56
+#  ...
+```
+
+`listener` komutu bir topic'in canlı içeriğini yazdırır. Örneğin aracın anlık duruşu:
+
+```bash
+nsh> listener vehicle_attitude
+#  TOPIC: vehicle_attitude
+#   vehicle_attitude
+#    timestamp: 87243147 (0.021 seconds ago)
+#    q: [0.9998, 0.0011, -0.0134, 0.0092]
+```
+
+## 5. Ağ Bağlantısı ve QGroundControl
+
+PX4 ile Linux tarafı bir ağ bağlantısıyla birbirine bağlıdır: NuttX tarafında `eth0`, Linux tarafında `eth1`.
+
+- **NuttX IP'si**: `192.168.10.2`
+- **Linux `eth1` IP'si**: `192.168.10.1`
+- **MAVLink Portu**: UDP `14550`
+
+### 5.1. Ağ Modülünün Kurulumu
+
+Ağ modülü paketini kurun ve kartı yeniden başlatın:
+
+```bash
+gemstone@t3-gem-o1:~$ sudo apt update
+gemstone@t3-gem-o1:~$ sudo apt install kernel-module-virtio-net-6.12.24-ti
+gemstone@t3-gem-o1:~$ sudo reboot
+```
+
+### 5.2. Bağlantının Yapılandırılması
+
+Bağlantının Linux tarafını yapılandırın (her açılıştan sonra gereklidir):
+
+```bash
+gemstone@t3-gem-o1:~$ sudo nmcli device set eth1 managed no
+gemstone@t3-gem-o1:~$ sudo ip link set eth1 up
+gemstone@t3-gem-o1:~$ sudo ip addr add 192.168.10.1/24 dev eth1
+gemstone@t3-gem-o1:~$ sudo sysctl -w net.ipv4.ip_forward=1
+```
+
+NuttX tarafını `nsh` konsolundan yapılandırın ve bağlantıyı doğrulayın:
+
+```bash
+nsh> ifconfig eth0 192.168.10.2 gw 192.168.10.1
+nsh> ifup eth0
+nsh> ping -c 3 192.168.10.1
+#  56 bytes from 192.168.10.1: icmp_seq=0 time=0.0 ms
+#  56 bytes from 192.168.10.1: icmp_seq=1 time=0.0 ms
+#  56 bytes from 192.168.10.1: icmp_seq=2 time=0.0 ms
+#  3 packets transmitted, 3 received, 0% packet loss
+```
+
+### 5.3. Kart Ağına PC'den Erişim
+
+Gemstone kartını USB Type-C kablosu ile bilgisayarınıza bağlayın ve `192.168.10.0/24` ağına kart üzerinden
+erişilebilmesi için bir rota ekleyin:
+
+```bash
+ubuntu@host:~$ sudo ip route add 192.168.10.0/24 via 192.168.7.2
+ubuntu@host:~$ ping -c 2 192.168.10.2
+#  64 bytes from 192.168.10.2: icmp_seq=1 ttl=64 time=0.42 ms
+#  64 bytes from 192.168.10.2: icmp_seq=2 ttl=64 time=0.31 ms
+```
+
+PC'nizin kart ağındaki kendi adresini bulun; bu adres bir sonraki adımda MAVLink hedefi olarak kullanılacaktır:
+
+```bash
+ubuntu@host:~$ ip route get 192.168.7.2 | grep -oP 'src \K\S+'
+#  192.168.7.60
+```
+
+### 5.4. QGroundControl Bağlantısı
+
+QGroundControl (QGC), aracı PC üzerinden izlemek ve kontrol etmek için kullanılan uygulamadır.
+[qgroundcontrol.com](https://qgroundcontrol.com/) adresinden kurun ve başlatın.
+
+`192.168.7.60` adresini bir önceki adımda bulduğunuz PC adresinizle değiştirerek telemetri bağlantısını `nsh`
+konsolundan başlatın:
+
+```bash
+nsh> mavlink start -u 14556 -o 14550 -t 192.168.7.60
+```
+
+QGC, UDP otomatik bağlantı etkinse (varsayılan ayar) aracı otomatik olarak algılayacak ve bağlanacaktır.
+
+## 6. Sorun Giderme
+
+### 6.1. Linux Tarafında eth1 Arayüzü Yok
+
+`virtio_net` modülünün yüklü olduğunu kontrol edin:
+
+```bash
+gemstone@t3-gem-o1:~$ lsmod | grep virtio_net
+#  virtio_net             45056  0
+#  net_failover           20480  1 virtio_net
+```
+
+Komut hiçbir şey yazdırmıyorsa modülü elle yükleyin ve tekrar kontrol edin:
+
+```bash
+gemstone@t3-gem-o1:~$ sudo modprobe virtio_net
+```
+
+### 6.2. MAVLink Bağlantısı Yok
+
+PC'den ağ yapılandırmasını doğrulayın; kart yanıt vermelidir:
+
+```bash
+ubuntu@host:~$ ping -c 2 192.168.10.2
+#  64 bytes from 192.168.10.2: icmp_seq=1 ttl=64 time=0.42 ms
+```
+
+Yanıt yoksa [Ağ Bağlantısı ve QGroundControl](#5-ağ-bağlantısı-ve-qgroundcontrol) bölümündeki adımları tekrarlayın.
+
+Telemetri bağlantısının NuttX tarafında çalıştığını ve veri gönderdiğini kontrol edin; `tx rate` değeri sıfırdan
+büyük olmalıdır:
+
+```bash
+nsh> mavlink status
+#  instance #0:
+#          ...
+#          tx rate avg: 2543 B/s
+```
+
+QGC'de Application Settings altında UDP otomatik bağlantının etkin olduğundan emin olun.

--- a/tr/roadmap.mdx
+++ b/tr/roadmap.mdx
@@ -77,8 +77,8 @@ hedeflenmektedir. Aşağıdaki tabloda güncel durum ve yapılacaklar bulunmakta
 | PWM sürücü desteği                                                                                          | `Tamamlandı`                   |
 | ECAP(APWM) sürücü desteği                                                                                   | `Tamamlandı`                   |
 | 40-pin HAT'te yer alan tüm pinler için pinmux ayarlamaları                                                  | `Tamamlandı`                   |
-| Gemstone üzerindeki Nuttx işletim sisteminde PX4 otopilotunun app olarak çalıştırılması                     | Gönüllü Geliştirici Bekleniyor |
-| R5 çekirdeğinde çalışan NuttX ile A53 çekirdeğinde çalışan Linux arası Texas IPC mekanizması ile haberleşme | Gönüllü Geliştirici Bekleniyor |
+| Gemstone üzerindeki Nuttx işletim sisteminde PX4 otopilotunun app olarak çalıştırılması                     | `Tamamlandı`                   |
+| R5 çekirdeğinde çalışan NuttX ile A53 çekirdeğinde çalışan Linux arası Texas IPC mekanizması ile haberleşme | `Tamamlandı`                   |
 | CAN Bus sürücü desteği                                                                                      | Gönüllü Geliştirici Bekleniyor |
 | USB sürücü desteği                                                                                          | Gönüllü Geliştirici Bekleniyor |
 | SD card ve eMMC sürücü desteği                                                                              | Gönüllü Geliştirici Bekleniyor |


### PR DESCRIPTION
Updates the PX4 project page (en + tr) for the current state of the port:

  - Full flight stack now starts automatically at boot; added section with
    verification commands and expected outputs
  - New networking + QGroundControl sections: module install, link setup,
    PC routing, UDP telemetry — all copy-paste steps with expected outputs
  - New troubleshooting section (no eth1, no MAVLink connection)
  - Fixed step order in compilation (dependencies before clone, venv after)
  - Added scp/picocom commands to the Running section
  - Roadmap: PX4-on-NuttX and R5–A53 IPC items marked completed; PX4 row
    scoped to PX4 only